### PR TITLE
simplify master key manifest logic by moving key-id definition to always be defined in keys manifest

### DIFF
--- a/features/0002-keys-generate.py
+++ b/features/0002-keys-generate.py
@@ -142,7 +142,9 @@ def build_manifest():
         }
 
     for key_bits, key_type, pem_key in RSA_KEYS:
-        keys["rsa-%s-%s" % (key_bits, key_type)] = {
+        key_name = "rsa-%s-%s" % (key_bits, key_type)
+        keys[key_name] = {
+            "key-id": key_name,
             "encrypt": True,
             "decrypt": key_type == "private",
             "algorithm": "rsa",

--- a/features/0002-keys.md
+++ b/features/0002-keys.md
@@ -2,7 +2,7 @@
 |           |             |
 |:----------|:------------|
 |__Feature__|Keys Manifest|
-|__Version__|1            |
+|__Version__|2            |
 |__Created__|2018-06-25   |
 |__Updated__|2018-08-14   |
 
@@ -79,6 +79,7 @@ Map structure mapping key names to key descriptions.
 
 User Defined keys are stored as JSON objects with the following attributes:
 
+* `key-id` : The key ID that should be used to identify any master keys that use this key material
 * `encrypt` : Boolean that defines whether or not this key can be used to encrypt
 * `decrypt` : Boolean that defines whether or not this key can be used to decrypt
 * `algorithm` : Defines the algorithm type
@@ -111,10 +112,11 @@ Keys can also reference an AWS KMS CMK. They should contain the following attrib
 {
     "manifest": {
         "type": "keys",
-        "version": 1
+        "version": 2
     },
     "keys": {
         "aes-256": {
+            "key-id": "aes-256-raw",
             "encrypt": true,
             "decrypt": true,
             "algorithm": "aes",
@@ -124,6 +126,7 @@ Keys can also reference an AWS KMS CMK. They should contain the following attrib
             "material": ["yar+8MbgZemJ9j41RjNpiYVCblujSNkYTIeKC/EEADc="]
         },
         "rsa-2048-private": {
+            "key-id": "rsa-2048-raw",
             "encrypt": true,
             "decrypt": true,
             "algorithm": "rsa",

--- a/features/0005-awses-master-key.md
+++ b/features/0005-awses-master-key.md
@@ -2,7 +2,7 @@
 |           |                              |
 |:----------|:-----------------------------|
 |__Feature__|AWS Encryption SDK Master Key |
-|__Version__|1                             |
+|__Version__|2                             |
 |__Created__|2016-08-13                    |
 |__Updated__|2018-08-13                    |
 
@@ -12,7 +12,7 @@ This serves as a reference of all features that this feature depends on.
 
 | Feature                                             | Min Version | Max Version |
 |-----------------------------------------------------|-------------|-------------|
-| [0002-keys](./0002-keys.md)                         | 1           | n/a         |
+| [0002-keys](./0002-keys.md)                         | 2           | n/a         |
 
 ## Experimental Implementations
 
@@ -69,7 +69,7 @@ A master key structure is defined as a JSON object with the following members:
         * `aws-kms`
         * `raw`
 * `key` : Name of key from a `keys` manifest
-* `key-id` : Master Key ID (optional) (default: `key` name or `key.key-id` for AWS KMS)
+    * The master key ID should always be `key.key-id`
 * `provider-id` : Master Key Provider ID (required for Raw Master Keys)
 * `encryption-algorithm` : Encryption Algorithm (required for Raw Master Keys)
     * Allowed Values


### PR DESCRIPTION
This came out of working with @ttjsu-aws to implement another handler for these. Upon reflection, we agreed that allowing `key-id` to be set in three different places (`[master-key].key-id`, `[master-key].key`, or `[key].key-id`) depending on the master key was overly complicated.

Instead, we decided to only allow setting of `key-id` in the keys manifest, and require that value for all keys. This might result in some duplicated keys definitions but will significantly simplify the master key definition processing.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.